### PR TITLE
fix: Code styling on mobile needs an `overflow: auto`.

### DIFF
--- a/components/markdown-styles.module.css
+++ b/components/markdown-styles.module.css
@@ -16,3 +16,7 @@
 .markdown h3 {
   @apply text-2xl mt-8 mb-4 leading-snug;
 }
+
+.markdown pre {
+  @apply w-full overflow-auto text-sm md:text-base pb-4;
+}


### PR DESCRIPTION
This PR adds some small fixes to the schedule section.

### Before
<img width="475" alt="image" src="https://user-images.githubusercontent.com/823088/216637467-b0cf6670-0b2d-49d6-a5fa-3f7cf0d52884.png">
<img width="418" alt="image" src="https://user-images.githubusercontent.com/823088/216637507-64cf7979-a2ab-4ce6-8b38-b3ac2fb81865.png">


### After
<img width="597" alt="image" src="https://user-images.githubusercontent.com/823088/216637312-dea75694-a405-4e44-8328-a948ceb45291.png">

Cheers 🍻
