### PR TITLE
Add hmr config for localhost in vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,9 @@ if (process.env.GITPOD_VITE_URL) {
 
 export default defineConfig({
     server: {
+        hmr: {
+            host: 'localhost'
+        },
         host: '0.0.0.0',
         ...extendedViteDevServerOptions
     },


### PR DESCRIPTION
Add localhost to hrm config in vite.config.js in order to use `npm run dev` in the container.