### PR TITLE
change sponsor on meetup create/edit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 ## TODO
 
+- tabela na base de dados para os sponsors, com 2 colunas "nome" e "link", para ser usado nos meetups e em outras que aparecem
 - Adicionar curation de nome "list".
 - Links para os socials dos speakers
 - Link p/ album partilhado, de modo à malta poder mandar fotos/videos dos eventos anteriores


### PR DESCRIPTION
with the new table sponsors on the db, is better to change the creation/edit form of the meetups, to insert the sponsor by "tag" and the links should be showned from the table.

also leave available to insert more than 1 sponsor